### PR TITLE
v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.5.0] - 20222-02-23
+## [0.6.0] - 2022-02-25
+
+### Changed
+* The type for the `-peak-to-tail` option in the CLI was changed from int to float. 
+
+## [0.5.0] - 2022-02-23
 
 ### Added
 * `threshold_noise` option to the command line script and as keyword argument to the fit function defined in DiffusionFitBase.

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Additionally, we have extended the framework to provide a model for fitting data
 
 ### What's new in
 
-#### version 0.5.0
- * New option to specify how the noise is estimated from the tail signal when applying the thresholding for images to determine whether to terminate the fitting early: the `-threshold_noise` option from the command line.  
+#### version 0.6.0
+ * The command line interface now accepts float values for the `-peak-to-tail` input option instead of just integers.
 
 See the [CHANGELOG](CHANGELOG.md) for additional details.  
 
@@ -53,16 +53,25 @@ Note that `diffusion-fit` has the following core dependencies:
    * [Numba](https://numba.pydata.org/)
 
 ### pip install
-You can install `diffusionfit` version 0.5.0 with `pip` sourced from the GitHub repo:
+You can install `diffusionfit` version 0.6.0 with `pip` sourced from the GitHub repo:
 
 ##### with git installed:
+Fresh install:
 ```
-pip install git+https://github.com/NTBEL/diffusion-fit@v0.5.0
+pip install git+https://github.com/NTBEL/diffusion-fit@v0.6.0
 ```
-
+Or to upgrade from an older version:
+```
+pip install --upgrade git+https://github.com/NTBEL/diffusion-fit@v0.6.0
+```
 ##### without git installed:
+Fresh install:
 ```
-pip install https://github.com/NTBEL/diffusion-fit/archive/refs/tags/v0.5.0.zip
+pip install https://github.com/NTBEL/diffusion-fit/archive/refs/tags/v0.6.0.zip
+```
+Or to upgrade from an older version:
+```
+pip install --upgrade https://github.com/NTBEL/diffusion-fit/archive/refs/tags/v0.6.0.zip
 ```
 ### Manual install
 First, download the repository. Then from the `diffusion-fit` folder/directory run

--- a/diffusionfit/__main__.py
+++ b/diffusionfit/__main__.py
@@ -57,7 +57,7 @@ parser.add_argument(
     "-peak-to-tail",
     nargs="?",
     metavar="peak_to_tail",
-    type=int,
+    type=float,
     default=3,
     help="Set the peak/tail threshold during step 1 fitting for terminating the fitting analysis.",
 )

--- a/diffusionfit/dfbase.py
+++ b/diffusionfit/dfbase.py
@@ -236,7 +236,7 @@ class DiffusionFitBase(ABC):
 
             if threshold_noise == "std_error":
                 tail_std /= np.sqrt(n_tail)
-            print(peak, tail_mean, tail_std, step1_threshold)
+            # print(peak, tail_mean, tail_std, step1_threshold)
             if apply_step1_threshold and (
                 peak < tail_mean + step1_threshold * tail_std
             ):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="diffusionfit",
-    version="0.5.0",
+    version="0.6.0",
     python_requires=">=3.9",
     install_requires=[
         "numpy",


### PR DESCRIPTION
The type for the `-peak-to-tail` option in the CLI was changed from int to float. A leftover print statement from previous version testing was commented out in the fit function of DiffusionFitBase.  